### PR TITLE
CI/CD foundation: PR builds, quality gates, tag-based releases, and Javadoc to Pages

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# Default owner: you
+*                 @Jay6877-git
+
+# CI & docs
+.github/**        @Jay6877-git
+
+# Java source
+src/**            @Jay6877-git

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule: { interval: "weekly" }
+    labels: ["deps", "ci"]
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule: { interval: "weekly" }
+    labels: ["deps", "java"]
+    open-pull-requests-limit: 5
+    # Optional: group minor/patch bumps to reduce PR noise
+    groups:
+      minor-and-patch:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,10 @@
+## What changed
+-
+
+## How to test
+- `mvn verify` should pass
+
+## Checklist
+- [ ] Build is green (status check **build**)
+- [ ] Tests added/updated if needed
+- [ ] Docs/README updated if needed

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: ci
 
 on:
   pull_request:
-    branches: [ main ]   
+    branches: [ main ]
   push:
     branches:
       - 'feature/**'
@@ -41,4 +41,7 @@ jobs:
             target/*.jar
             target/surefire-reports/**
             target/failsafe-reports/**
+            target/checkstyle-result.xml
+            target/spotbugsXml.xml
+            target/site/jacoco/**
           retention-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,44 @@
+name: ci
+
+on:
+  pull_request:
+    branches: [ main ]   
+  push:
+    branches:
+      - 'feature/**'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+          cache: maven
+
+      - name: Build & test (Maven verify)
+        run: mvn -B -DskipTests=false verify
+
+      - name: Upload build artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-artifacts-${{ github.run_number }}
+          path: |
+            target/*.jar
+            target/surefire-reports/**
+            target/failsafe-reports/**
+          retention-days: 7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,3 +64,17 @@ jobs:
             target/*.jar
             target/*.jar.sha256
             target/site/apidocs.zip
+
+      - name: Stage Javadoc for Pages
+        run: |
+          rm -rf gh-pages
+          mkdir -p gh-pages/docs/${{ steps.vars.outputs.version }} gh-pages/latest
+          cp -r target/site/apidocs/* gh-pages/docs/${{ steps.vars.outputs.version }}/
+          cp -r target/site/apidocs/* gh-pages/latest/
+
+      - name: Publish to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: gh-pages
+          commit_message: "docs: publish Javadoc for v${{ steps.vars.outputs.version }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,10 +3,10 @@ name: release
 on:
   push:
     tags:
-      - 'v*'   # e.g., v0.1.0
+      - 'v*'   # e.g., v0.1.2
 
 permissions:
-  contents: write   # needed to create a GitHub Release
+  contents: write
 
 jobs:
   release:
@@ -34,18 +34,18 @@ jobs:
 
       - name: Build shaded JAR + Javadoc
         run: |
-          mvn -B -P release -DskipTests=false package
-          mvn -B javadoc:javadoc
+          # Build executable fat JAR (using your release profile) and generate Javadoc + javadoc.jar
+          mvn -B -P release -DskipTests=false package javadoc:javadoc javadoc:jar
 
       - name: Compute checksums
         run: |
           cd target
           for f in *.jar; do sha256sum "$f" > "$f.sha256"; done
 
-      - name: Zip Javadoc
+      - name: Zip Javadoc (if present)
+        if: ${{ hashFiles('target/site/apidocs/**/*') != '' }}
         run: |
-          cd target/site
-          zip -r apidocs.zip apidocs
+          (cd target/site && zip -r apidocs.zip apidocs)
 
       - name: Generate simple release notes
         run: |
@@ -65,12 +65,18 @@ jobs:
             target/*.jar.sha256
             target/site/apidocs.zip
 
+      # ---- GitHub Pages publish (safe even if no docs) ----
       - name: Stage Javadoc for Pages
         run: |
           rm -rf gh-pages
-          mkdir -p gh-pages/docs/${{ steps.vars.outputs.version }} gh-pages/latest
-          cp -r target/site/apidocs/* gh-pages/docs/${{ steps.vars.outputs.version }}/
-          cp -r target/site/apidocs/* gh-pages/latest/
+          mkdir -p gh-pages
+          if [ -d target/site/apidocs ]; then
+            mkdir -p gh-pages/docs/${{ steps.vars.outputs.version }} gh-pages/latest
+            cp -r target/site/apidocs/* gh-pages/docs/${{ steps.vars.outputs.version }}/
+            cp -r target/site/apidocs/* gh-pages/latest/
+          else
+            echo "<!doctype html><h1>No Javadoc for v${{ steps.vars.outputs.version }}</h1>" > gh-pages/index.html
+          fi
 
       - name: Publish to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,66 @@
+name: release
+
+on:
+  push:
+    tags:
+      - 'v*'   # e.g., v0.1.0
+
+permissions:
+  contents: write   # needed to create a GitHub Release
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+          cache: maven
+
+      - name: Extract version from tag
+        id: vars
+        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Set project version to tag
+        run: mvn -B versions:set -DnewVersion='${{ steps.vars.outputs.version }}' -DgenerateBackupPoms=false
+
+      - name: Build shaded JAR + Javadoc
+        run: |
+          mvn -B -P release -DskipTests=false package
+          mvn -B javadoc:javadoc
+
+      - name: Compute checksums
+        run: |
+          cd target
+          for f in *.jar; do sha256sum "$f" > "$f.sha256"; done
+
+      - name: Zip Javadoc
+        run: |
+          cd target/site
+          zip -r apidocs.zip apidocs
+
+      - name: Generate simple release notes
+        run: |
+          set -e
+          PREV=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || true)
+          if [ -n "$PREV" ]; then RANGE="$PREV..HEAD"; else RANGE="$(git rev-list --max-parents=0 HEAD)..HEAD"; fi
+          git log --pretty=format:'- %s (%h)' $RANGE > RELEASE_NOTES.md || echo "- Initial release" > RELEASE_NOTES.md
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: v${{ steps.vars.outputs.version }}
+          body_path: RELEASE_NOTES.md
+          files: |
+            target/*.jar
+            target/*.jar.sha256
+            target/site/apidocs.zip

--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+CI skeleton coming soon.

--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,52 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
+    <profiles>
+        <profile>
+            <id>release</id>
+            <build>
+                <plugins>
+                    <!-- Make the JAR executable by setting Main-Class -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-jar-plugin</artifactId>
+                        <version>3.3.0</version>
+                        <configuration>
+                            <archive>
+                                <manifest>
+                                    <addClasspath>true</addClasspath>
+                                    <mainClass>com.jaypatel.Main</mainClass>
+                                </manifest>
+                            </archive>
+                        </configuration>
+                    </plugin>
+
+                    <!-- Create a fat (shaded) JAR on package -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-shade-plugin</artifactId>
+                        <version>3.5.3</version>
+                        <executions>
+                            <execution>
+                                <phase>package</phase>
+                                <goals><goal>shade</goal></goals>
+                                <configuration>
+                                    <createDependencyReducedPom>true</createDependencyReducedPom>
+                                    <transformers>
+                                        <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                            <mainClass>com.jaypatel.Main</mainClass>
+                                        </transformer>
+                                    </transformers>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
+
     <build>
         <plugins>
             <!-- Checkstyle: fail build on style violations (Google checks) -->

--- a/pom.xml
+++ b/pom.xml
@@ -126,6 +126,16 @@
                     </execution>
                 </executions>
             </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>3.6.3</version>
+                <configuration>
+                    <failOnError>false</failOnError>
+                    <source>17</source>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -14,4 +14,72 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
+    <build>
+        <plugins>
+            <!-- Checkstyle: fail build on style violations (Google checks) -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <version>3.3.1</version>
+                <configuration>
+                    <configLocation>google_checks.xml</configLocation>
+                    <encoding>UTF-8</encoding>
+                    <consoleOutput>true</consoleOutput>
+                    <failsOnError>true</failsOnError>
+                    <failOnViolation>true</failOnViolation>
+                    <linkXRef>false</linkXRef>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>checkstyle</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <!-- SpotBugs: catch common bugs; fail build on findings -->
+            <plugin>
+                <groupId>com.github.spotbugs</groupId>
+                <artifactId>spotbugs-maven-plugin</artifactId>
+                <version>4.8.5.0</version>
+                <configuration>
+                    <effort>Max</effort>
+                    <threshold>Low</threshold>
+                    <failOnError>true</failOnError>
+                    <xmlOutput>true</xmlOutput>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <!-- JaCoCo: generate coverage report at target/site/jacoco/index.html -->
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.11</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>


### PR DESCRIPTION
## Summary
Sets up a simple, portfolio-friendly pipeline:
- PR builds on JDK 17 with Maven (`build` job) and uploaded artifacts
- Quality gates: Checkstyle, SpotBugs, JaCoCo (enforced in `verify`)
- Tag-based releases (fat JAR + checksums + javadoc.jar)
- Javadoc published to GitHub Pages (`/latest/` and versioned)

## What changed
- `.github/workflows/ci.yml`: PR and feature/* pushes run `mvn verify`, cache Maven, upload JAR + reports
- `.github/workflows/release.yml`: on `v*` tag → set version, build shaded JAR, compute checksums, create GitHub Release, publish Javadoc to Pages
- `pom.xml`:
  - Add Checkstyle, SpotBugs, JaCoCo (bound to `verify`)
  - Add `release` profile (jar + shade) with `mainClass` = `com.jaypatel.Main`
  - Add `maven-javadoc-plugin` (lenient) so releases don’t fail when docs are minimal
- (Optional in repo) `.github/dependabot.yml` + `.github/CODEOWNERS`

## How to test
1. **PR build:** push to this branch → Actions should show ✅ **build**; artifact contains `target/*.jar`, `checkstyle-result.xml`, `spotbugsXml.xml`, `site/jacoco/*`.
2. **Branch protection:** in Settings → Branches → `main`, require status check **build** to pass before merge.
3. **Release:** after merging, tag `v0.1.0`:
   ```bash
   git switch main && git pull
   git tag v0.1.0
   git push origin v0.1.0

Closes #1
Closes #2
Closes #3 
Closes #4 

