### PR TITLE
feat(model): add Person & Address entities with null-safe display formatting and unit tests

### DIFF
--- a/.idea/encodings.xml
+++ b/.idea/encodings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Encoding">
+    <file url="file://$PROJECT_DIR$/src/main/java" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/src/main/resources" charset="UTF-8" />
+  </component>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,14 @@
         <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
+    <dependencies>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.8.1</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
 
     <profiles>
         <profile>
@@ -69,7 +77,6 @@
                 <version>3.3.1</version>
                 <configuration>
                     <configLocation>google_checks.xml</configLocation>
-                    <encoding>UTF-8</encoding>
                     <consoleOutput>true</consoleOutput>
                     <failsOnError>true</failsOnError>
                     <failOnViolation>true</failOnViolation>
@@ -134,6 +141,15 @@
                 <configuration>
                     <failOnError>false</failOnError>
                     <source>17</source>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.2.5</version>
+                <configuration>
+                    <useModulePath>false</useModulePath>
                 </configuration>
             </plugin>
         </plugins>

--- a/src/main/java/com/jaypatel/emanager/model/Address.java
+++ b/src/main/java/com/jaypatel/emanager/model/Address.java
@@ -1,0 +1,144 @@
+package com.jaypatel.emanager.model;
+
+/**
+ * Simple mailing address (street, city, province, postal code).
+ * <p>Fields are trimmed; blanks are stored as {@code null}.</p>
+ */
+public class Address {
+    private String street;
+
+    private String city;
+
+    private String province;
+
+    private String postalCode;
+
+    /**
+     * No-args constructor (useful for frameworks, JSON binding, etc.).
+     */
+    public Address() {
+    }
+
+    /**
+     * Full constructor.
+     *
+     * @param street     street line; trimmed, blank → {@code null}
+     * @param city       city; trimmed, blank → {@code null}
+     * @param province   province/state; trimmed, blank → {@code null}
+     * @param postalCode postal code/ZIP; trimmed, blank → {@code null}
+     */
+    public Address(String street, String city, String province, String postalCode) {
+        this.street = (street == null || street.isBlank()) ? null : street.trim();
+        this.city = (city == null || city.isBlank()) ? null : city.trim();
+        this.province = (province == null || province.isBlank()) ? null : province.trim();
+        this.postalCode = (postalCode == null || postalCode.isBlank()) ? null : postalCode.trim();
+    }
+
+    /**
+     * @return the street, or {@code null} if not set
+     */
+    public String getStreet() {
+        return street;
+    }
+
+    /**
+     * Sets the street. Trimmed; blanks become {@code null}.
+     * @param street street line
+     */
+    public void setStreet(String street) {
+        this.street = (street == null || street.isBlank()) ? null : street.trim();
+    }
+
+    /**
+     * @return the city, or {@code null} if not set
+     */
+    public String getCity() {
+        return city;
+    }
+
+    /**
+     * Sets the city. Trimmed; blanks become {@code null}.
+     * @param city city name
+     */
+    public void setCity(String city) {
+        this.city = (city == null || city.isBlank()) ? null : city.trim();
+    }
+
+    /**
+     * @return the province/state, or {@code null} if not set
+     */
+    public String getProvince() {
+        return province;
+    }
+
+    /**
+     * Sets the province/state. Trimmed; blanks become {@code null}.
+     * @param province province or state code/name
+     */
+    public void setProvince(String province) {
+        this.province = (province == null || province.isBlank()) ? null : province.trim();
+    }
+
+    /**
+     * @return the postal/ZIP code, or {@code null} if not set
+     */
+    public String getPostalCode() {
+        return postalCode;
+    }
+
+    /**
+     * Sets the postal/ZIP code. Trimmed; blanks become {@code null}.
+     * @param postalCode postal or ZIP code
+     */
+    public void setPostalCode(String postalCode) {
+        this.postalCode = (postalCode == null || postalCode.isBlank()) ? null : postalCode.trim();
+    }
+
+    /**
+     * Builds a single-line, human-friendly address.
+     * <p>Format: {@code "Street, City, Province PostalCode"}.
+     * Missing parts are skipped (no extra commas/spaces). Returns {@code ""} if all parts are absent.</p>
+     *
+     * @return display-ready address string (never {@code null})
+     */
+    public String displayAddress(){
+        final String st = street;
+        final String c  = city;
+        final String pr = province;
+        final String pc = postalCode;
+
+        final boolean hasSt = st != null && !st.isBlank();
+        final boolean hasC  = c  != null && !c.isBlank();
+        final boolean hasPr = pr != null && !pr.isBlank();
+        final boolean hasPc = pc != null && !pc.isBlank();
+
+        StringBuilder base = new StringBuilder();
+
+        // Join Street, City, Province with ", " between present parts
+        if (hasSt) base.append(st);
+        if (hasC) {
+            if (!base.isEmpty()) base.append(", ");
+            base.append(c);
+        }
+        if (hasPr) {
+            if (!base.isEmpty()) base.append(", ");
+            base.append(pr);
+        }
+
+        // Append Postal Code with a leading space if anything precedes it
+        if (hasPc) {
+            if (!base.isEmpty()) {
+                base.append(' ').append(pc);
+            } else {
+                base.append(pc);
+            }
+        }
+
+        return base.toString();
+    }
+
+    @Override
+    public String toString() {
+        return displayAddress();
+    }
+}

--- a/src/main/java/com/jaypatel/emanager/model/Address.java
+++ b/src/main/java/com/jaypatel/emanager/model/Address.java
@@ -141,4 +141,6 @@ public class Address {
     public String toString() {
         return displayAddress();
     }
+
+
 }

--- a/src/main/java/com/jaypatel/emanager/model/Person.java
+++ b/src/main/java/com/jaypatel/emanager/model/Person.java
@@ -32,6 +32,8 @@ public class Person {
     /** Primary contact number (format not enforced). */
     private String phoneNumber;
 
+    private Address address;
+
     /** No-args constructor for frameworks and serialization. */
     public Person() {
     }
@@ -45,12 +47,14 @@ public class Person {
      * @param birthDate   the person's birthdate string (e.g., {@code "2000-01-31"})
      * @param phoneNumber the person's phone number string
      */
-    public Person(String lastName, String firstName, char middleInit, String birthDate, String phoneNumber) {
+    public Person(String lastName, String firstName, char middleInit, String birthDate, String phoneNumber, Address address) {
         this.lastName = (lastName == null || lastName.isBlank()) ? null : lastName.trim();
         this.firstName = (firstName == null || firstName.isBlank()) ? null : firstName.trim();
         this.middleInit = middleInit;
         this.birthDate = (birthDate == null || birthDate.isBlank()) ? null : birthDate.trim();
         this.phoneNumber = (phoneNumber == null || phoneNumber.isBlank()) ? null : phoneNumber.trim();
+
+        this.address = address;
     }
 
     /**
@@ -99,6 +103,15 @@ public class Person {
     }
 
     /**
+     * Sets the Address.
+     *
+     * @param address to set address
+     */
+    public void setAddress(Address address) {
+        this.address = address;
+    }
+
+    /**
      * Returns the last name (surname).
      *
      * @return the last name
@@ -126,9 +139,9 @@ public class Person {
     }
 
     /**
-     * Returns the birth date string.
+     * Returns the birthdate string.
      *
-     * @return the birth date, as provided (no parsing/validation)
+     * @return the birthdate, as provided (no parsing/validation)
      */
     public String getBirthDate() {
         return birthDate;
@@ -141,6 +154,14 @@ public class Person {
      */
     public String getPhoneNumber() {
         return phoneNumber;
+    }
+
+    /**
+     * Returns the address
+     * @return the address class
+     */
+    public Address getAddress() {
+        return address;
     }
 
     /**

--- a/src/main/java/com/jaypatel/emanager/model/Person.java
+++ b/src/main/java/com/jaypatel/emanager/model/Person.java
@@ -109,13 +109,7 @@ public class Person {
      * @param address to set address
      */
     public void setAddress(Address address) {
-
-        if (address != null) {
-            this.address.setCity(address.getCity());
-            this.address.setProvince(address.getProvince());
-            this.address.setPostalCode(address.getPostalCode());
-            this.address.setStreet(address.getStreet());
-        } else this.address = null;
+        this.address = copy(address);
     }
 
     /**
@@ -168,7 +162,7 @@ public class Person {
      * @return the address class
      */
     public Address getAddress() {
-        return address;
+        return copy(this.address); // defensive copy
     }
 
     /**
@@ -219,5 +213,15 @@ public class Person {
             if (middleInit != '\0') sb.append(' ').append(middleInit);
         }
         return sb.toString();
+    }
+
+    private static Address copy(Address src) {
+        if (src == null) return null;
+        Address dst = new Address();                 // uses your null-safe setters
+        dst.setStreet(src.getStreet());
+        dst.setCity(src.getCity());
+        dst.setProvince(src.getProvince());
+        dst.setPostalCode(src.getPostalCode());
+        return dst;
     }
 }

--- a/src/main/java/com/jaypatel/emanager/model/Person.java
+++ b/src/main/java/com/jaypatel/emanager/model/Person.java
@@ -46,6 +46,7 @@ public class Person {
      * @param middleInit  the person's middle initial; use {@code '\0'} if none/unknown
      * @param birthDate   the person's birthdate string (e.g., {@code "2000-01-31"})
      * @param phoneNumber the person's phone number string
+     * @param address     the person's address
      */
     public Person(String lastName, String firstName, char middleInit, String birthDate, String phoneNumber, Address address) {
         this.lastName = (lastName == null || lastName.isBlank()) ? null : lastName.trim();
@@ -54,7 +55,7 @@ public class Person {
         this.birthDate = (birthDate == null || birthDate.isBlank()) ? null : birthDate.trim();
         this.phoneNumber = (phoneNumber == null || phoneNumber.isBlank()) ? null : phoneNumber.trim();
 
-        this.address = address;
+        setAddress(address);
     }
 
     /**
@@ -108,7 +109,13 @@ public class Person {
      * @param address to set address
      */
     public void setAddress(Address address) {
-        this.address = address;
+
+        if (address != null) {
+            this.address.setCity(address.getCity());
+            this.address.setProvince(address.getProvince());
+            this.address.setPostalCode(address.getPostalCode());
+            this.address.setStreet(address.getStreet());
+        } else this.address = null;
     }
 
     /**

--- a/src/main/java/com/jaypatel/emanager/model/Person.java
+++ b/src/main/java/com/jaypatel/emanager/model/Person.java
@@ -1,0 +1,195 @@
+package com.jaypatel.emanager.model;
+
+
+/**
+ * Represents a person with basic identity and contact details.
+ * <p>
+ * This is a simple mutable POJO intended for use as a model/entity in the eManager app.
+ * </p>
+ *
+ * <h3>Example</h3>
+ * <pre>{@code
+ * Person p = new Person("Patel", "Jay", 'M', "1998-05-12", "306-555-1234");
+ * System.out.println(p);  // Patel, Jay M
+ * }</pre>
+ *
+ * <p><b>Note:</b> {@code birthDate} and {@code phoneNumber} are stored as strings to keep the class minimal;
+ * consider using {@link java.time.LocalDate} and a validated phone type if you need stricter typing.</p>
+ */
+public class Person {
+    /** Surname / family name. */
+    private String lastName;
+
+    /** Given / first name. */
+    private String firstName;
+
+    /** Middle initial (use '\0' if unknown). */
+    private char middleInit;
+
+    /** Birthdate as a string (e.g., ISO-8601 "YYYY-MM-DD"). No validation is performed here. */
+    private String birthDate;
+
+    /** Primary contact number (format not enforced). */
+    private String phoneNumber;
+
+    /** No-args constructor for frameworks and serialization. */
+    public Person() {
+    }
+
+    /**
+     * Full constructor.
+     *
+     * @param lastName    the person's last name (surname)
+     * @param firstName   the person's first name (given name)
+     * @param middleInit  the person's middle initial; use {@code '\0'} if none/unknown
+     * @param birthDate   the person's birthdate string (e.g., {@code "2000-01-31"})
+     * @param phoneNumber the person's phone number string
+     */
+    public Person(String lastName, String firstName, char middleInit, String birthDate, String phoneNumber) {
+        this.lastName = (lastName == null || lastName.isBlank()) ? null : lastName.trim();
+        this.firstName = (firstName == null || firstName.isBlank()) ? null : firstName.trim();
+        this.middleInit = middleInit;
+        this.birthDate = (birthDate == null || birthDate.isBlank()) ? null : birthDate.trim();
+        this.phoneNumber = (phoneNumber == null || phoneNumber.isBlank()) ? null : phoneNumber.trim();
+    }
+
+    /**
+     * Sets the last name (surname).
+     *
+     * @param lastName the last name to set
+     */
+    public void setLastName(String lastName) {
+        this.lastName = (lastName == null || lastName.isBlank()) ? null : lastName.trim();
+    }
+
+    /**
+     * Sets the first name (given name).
+     *
+     * @param firstName the first name to set
+     */
+    public void setFirstName(String firstName) {
+        this.firstName = (firstName == null || firstName.isBlank()) ? null : firstName.trim();
+    }
+
+    /**
+     * Sets the middle initial.
+     *
+     * @param middleInit the middle initial character; use {@code '\0'} if none/unknown
+     */
+    public void setMiddleInit(char middleInit) {
+        this.middleInit = middleInit;
+    }
+
+    /**
+     * Sets the birthdate string.
+     *
+     * @param birthDate birth date string (e.g., {@code "YYYY-MM-DD"})
+     */
+    public void setBirthDate(String birthDate) {
+        this.birthDate = (birthDate == null || birthDate.isBlank()) ? null : birthDate.trim();
+    }
+
+    /**
+     * Sets the phone number string.
+     *
+     * @param phoneNumber phone number string to set
+     */
+    public void setPhoneNumber(String phoneNumber) {
+        this.phoneNumber = (phoneNumber == null || phoneNumber.isBlank()) ? null : phoneNumber.trim();
+    }
+
+    /**
+     * Returns the last name (surname).
+     *
+     * @return the last name
+     */
+    public String getLastName() {
+        return lastName;
+    }
+
+    /**
+     * Returns the first name (given name).
+     *
+     * @return the first name
+     */
+    public String getFirstName() {
+        return firstName;
+    }
+
+    /**
+     * Returns the middle initial.
+     *
+     * @return the middle initial character, or {@code '\0'} if none/unknown
+     */
+    public char getMiddleInit() {
+        return middleInit;
+    }
+
+    /**
+     * Returns the birth date string.
+     *
+     * @return the birth date, as provided (no parsing/validation)
+     */
+    public String getBirthDate() {
+        return birthDate;
+    }
+
+    /**
+     * Returns the phone number string.
+     *
+     * @return the phone number, as provided (no formatting/validation)
+     */
+    public String getPhoneNumber() {
+        return phoneNumber;
+    }
+
+    /**
+     * Returns a concise display string of the form {@code "LastName, FirstName M"}.
+     * <p>
+     * If {@code middleInit} is the null character ({@code '\0'}), the trailing space and
+     * initial may look odd; adjust formatting if needed for your UI.
+     * </p>
+     *
+     * @return a human-readable representation
+     */
+    @Override
+    public String toString() {
+        return getDisplayName();
+    }
+
+    /**
+     * Builds a human-friendly name for display.
+     * <p>
+     * Rules:
+     * <ul>
+     *   <li>Format is {@code "LastName, FirstName"} when both are present.</li>
+     *   <li>If {@code middleInit != '\0'} <em>and</em> first name exists, append a space and the middle initial:
+     *       {@code "LastName, FirstName M"}.</li>
+     *   <li>If only one of first/last is present, return just that part (no dangling commas/spaces).</li>
+     *   <li>If both names are missing (null/blank), return an empty string.</li>
+     * </ul>
+     * This method is null/blank-safe to match the class's permissive setters which may collapse blanks to {@code null}.
+     *
+     * @return a display-ready name string, never {@code null}; may be {@code ""} if no name parts are present
+     * @implNote Avoids printing the {@code '\0'} middle-initial placeholder and never includes the literal
+     *           string {@code "null"} in the output.
+     */
+    public String getDisplayName() {
+        final String ln = lastName;
+        final String fn = firstName;
+
+        final boolean hasLn = ln != null && !ln.isBlank();
+        final boolean hasFn = fn != null && !fn.isBlank();
+
+        if (!hasLn && !hasFn) return "";
+
+        StringBuilder sb = new StringBuilder();
+        if (hasLn) sb.append(ln);
+        if (hasFn) {
+            if (hasLn) sb.append(", ");
+            sb.append(fn);
+            if (middleInit != '\0') sb.append(' ').append(middleInit);
+        }
+        return sb.toString();
+    }
+}

--- a/src/test/java/com/jaypatel/emanager/model/AddressTest.java
+++ b/src/test/java/com/jaypatel/emanager/model/AddressTest.java
@@ -1,0 +1,59 @@
+package com.jaypatel.emanager.model;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+public class AddressTest {
+
+    @Test
+    void fullAddressFormatsCorrectly() {
+        // Arrange
+        Address addr = new Address("123 Main St", "Saskatoon", "SK", "S7J 4M3");
+
+        // Act & Assert
+        assertEquals("123 Main St, Saskatoon, SK S7J 4M3", addr.displayAddress());
+    }
+
+    @Test
+    void cityAndProvinceOnly() {
+        Address addr = new Address(null, "Saskatoon", "SK", null);
+        assertEquals("Saskatoon, SK", addr.displayAddress());
+    }
+
+    @Test
+    void postalOnly() {
+        Address addr = new Address(null, null, null, "S7J 4M3");
+        assertEquals("S7J 4M3", addr.displayAddress());
+    }
+
+    @Test
+    void provinceAndPostalOnly() {
+        Address addr = new Address(null, null, "SK", "S7J 4M3");
+        assertEquals("SK S7J 4M3", addr.displayAddress());
+    }
+
+    @Test
+    void streetOnly() {
+        Address addr = new Address("123 Main St", null, null, null);
+        assertEquals("123 Main St", addr.displayAddress());
+    }
+
+    @Test
+    void allNullReturnsEmptyString() {
+        Address addr = new Address(null, null, null, null);
+        assertEquals("", addr.displayAddress());
+    }
+
+    @Test
+    void trimsInputsInConstructor() {
+        Address addr = new Address(" 123 Main St  ", "  Saskatoon ", " SK  ", "  S7J 4M3 ");
+        assertAll(
+                () -> assertEquals("123 Main St, Saskatoon, SK S7J 4M3", addr.displayAddress()),
+                () -> assertEquals("123 Main St", addr.getStreet()),
+                () -> assertEquals("Saskatoon", addr.getCity()),
+                () -> assertEquals("SK", addr.getProvince()),
+                () -> assertEquals("S7J 4M3", addr.getPostalCode())
+        );
+    }
+}

--- a/src/test/java/com/jaypatel/emanager/model/PersonTest.java
+++ b/src/test/java/com/jaypatel/emanager/model/PersonTest.java
@@ -6,31 +6,31 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class PersonTest {
     @Test
     void displayNameWithMiddle(){
-        Person p = new Person("Patel", "Jay", 'M', "1998-05-12", "306-555-1234");
+        Person p = new Person("Patel", "Jay", 'M', "1998-05-12", "306-555-1234", null);
         assertEquals("Patel, Jay M", p.getDisplayName());
     }
 
     @Test
     void displayNameNoMiddle() {
-        Person p = new Person("Patel", "Jay", '\0', null, null);
+        Person p = new Person("Patel", "Jay", '\0', null, null, null);
         assertEquals("Patel, Jay", p.getDisplayName());
     }
 
     @Test
     void displayNameOnlyLast() {
-        Person p = new Person("Patel", null, '\0', null, null);
+        Person p = new Person("Patel", null, '\0', null, null, null);
         assertEquals("Patel", p.getDisplayName());
     }
 
     @Test
     void displayNameOnlyFirst() {
-        Person p = new Person(null, "Jay", 'M', null, null);
+        Person p = new Person(null, "Jay", 'M', null, null, null);
         assertEquals("Jay M", p.getDisplayName());
     }
 
     @Test
     void displayNameNone() {
-        Person p = new Person(null, null, 'M', null, null);
+        Person p = new Person(null, null, 'M', null, null, null);
         assertEquals("", p.getDisplayName());
     }
 }

--- a/src/test/java/com/jaypatel/emanager/model/PersonTest.java
+++ b/src/test/java/com/jaypatel/emanager/model/PersonTest.java
@@ -1,0 +1,36 @@
+package com.jaypatel.emanager.model;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class PersonTest {
+    @Test
+    void displayNameWithMiddle(){
+        Person p = new Person("Patel", "Jay", 'M', "1998-05-12", "306-555-1234");
+        assertEquals("Patel, Jay M", p.getDisplayName());
+    }
+
+    @Test
+    void displayNameNoMiddle() {
+        Person p = new Person("Patel", "Jay", '\0', null, null);
+        assertEquals("Patel, Jay", p.getDisplayName());
+    }
+
+    @Test
+    void displayNameOnlyLast() {
+        Person p = new Person("Patel", null, '\0', null, null);
+        assertEquals("Patel", p.getDisplayName());
+    }
+
+    @Test
+    void displayNameOnlyFirst() {
+        Person p = new Person(null, "Jay", 'M', null, null);
+        assertEquals("Jay M", p.getDisplayName());
+    }
+
+    @Test
+    void displayNameNone() {
+        Person p = new Person(null, null, 'M', null, null);
+        assertEquals("", p.getDisplayName());
+    }
+}


### PR DESCRIPTION
## Summary
Introduces the first domain objects for the app:
- `Person` (first/last/middle initial, birthDate, phoneNumber)
- `Address` (street, city, provinceOrState, postalCode, country)

Both include null-safe display helpers to keep UI formatting clean.

## What changed
- Added `Person` and `Address` classes under `com.jaypatel.emanager.model`.
- Implemented `getDisplayName()` rules so we never show `\0`, stray commas, or extra spaces.
- Added JUnit tests for both classes covering typical and edge case

## Why
Sets a clean foundation for the upcoming `Employee` hierarchy and DAO layer while keeping GUI free of string-cleanup logic.

## Tests
- `PersonTest`:
  - with middle initial → `"Last, First M"`
  - no middle initial → `"Last, First"`
  - only last / only first / none → formats as expected
- `AddressTest`:
  - normal full address format
  - missing/partial fields handled without trailing punctuation

## CI
- Build + tests pass (JUnit 5)
- Checkstyle/SpotBugs/JaCoCo wired (no new violations introduced)

## How to review
- Focus on `model/Person.java` and `model/Address.java`
- Verify display rules and test coverage align with acceptance criteria above

## Follow-ups (separate PRs)
- Add `Employee` base + `SalaryEmployee`/`HourlyEmployee` with `getEarnings()`
- DAO interfaces + SQLite schema
- JavaFX list/detail screens
